### PR TITLE
add custom images support

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -268,6 +268,13 @@ exports.audio = async(pathFolder, title, lang) => {
     podcast.image = uid(16);
     //get image
     if(filesImage.length > 0) {
+      // allows for custom images for each story by using indexed jpg filenames
+      // just make sure to name files: 1.jpg, 2.jpg, 3.jpg, etc in the same folder as mp3 files
+      try {
+        for (const img of filesImage)
+          await fse.copy(img, folderAssetsBefore + '/'+ require('path').basename(img));
+      } catch (e) {}
+
       await fse.copy(filesImage[0], folderAssetsBefore + '/'+ podcast.image + '.jpg');
       await fse.copy(filesImage[0], folderAssetsBefore + '/thumbnail');
     } else {


### PR DESCRIPTION
This enables adding custom images for each chapter/story by using
indexed-named jpg files, it looks like some part of the support for this
was already there in the `marketraitment` function so this adds copying
the jpg files into assets_before folder in order to make sure they get
used instead.