### PR TITLE
Fix m4a files support

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -231,158 +231,158 @@ exports.audio = async(pathFolder, title, lang) => {
     files = listFilesSync(pathFolder, 'm4a');
   }
 
-    if (files.length == 0) {
-      console.error("No mp3 OR m4a files in directory.");
-      process.exitCode = 1;
-      return;
-    }
+  if (files.length == 0) {
+    console.error("No mp3 OR m4a files in directory.");
+    process.exitCode = 1;
+    return;
+  }
 
-    const bar1 = new cliProgress.SingleBar({}, cliProgress.Presets.shades_classic);
-    var limit = files.length;
-    bar1.start(parseInt(limit) + 8, 0);
-    // 
-    var podcast = await fse.readJSON(__dirname + '/assets/podcast.json');
-    var luniiExport = await fse.readJSON(__dirname + '/assets/luniiExport.json');
-    var luniiExport_PackSelectionStage = await fse.readJSON(__dirname + '/assets/luniiExport_PackSelectionStage.json');
-    var luniiExport_Story = await fse.readJSON(__dirname + '/assets/luniiExport_Story.json');
-    var luniiExport_StoryAction = await fse.readJSON(__dirname + '/assets/luniiExport_StoryAction.json');
-    var luniiExport_questionStage = await fse.readJSON(__dirname + '/assets/luniiExport_questionStage.json');
-    var luniiExport_menuoptionStage = await fse.readJSON(__dirname + '/assets/luniiExport_menuoptionStage.json');
-    var luniiExport_questionAction = await fse.readJSON(__dirname + '/assets/luniiExport_questionAction.json');
-    var luniiExport_optionAction = await fse.readJSON(__dirname + '/assets/luniiExport_optionAction.json');
+  const bar1 = new cliProgress.SingleBar({}, cliProgress.Presets.shades_classic);
+  var limit = files.length;
+  bar1.start(parseInt(limit) + 8, 0);
+  // 
+  var podcast = await fse.readJSON(__dirname + '/assets/podcast.json');
+  var luniiExport = await fse.readJSON(__dirname + '/assets/luniiExport.json');
+  var luniiExport_PackSelectionStage = await fse.readJSON(__dirname + '/assets/luniiExport_PackSelectionStage.json');
+  var luniiExport_Story = await fse.readJSON(__dirname + '/assets/luniiExport_Story.json');
+  var luniiExport_StoryAction = await fse.readJSON(__dirname + '/assets/luniiExport_StoryAction.json');
+  var luniiExport_questionStage = await fse.readJSON(__dirname + '/assets/luniiExport_questionStage.json');
+  var luniiExport_menuoptionStage = await fse.readJSON(__dirname + '/assets/luniiExport_menuoptionStage.json');
+  var luniiExport_questionAction = await fse.readJSON(__dirname + '/assets/luniiExport_questionAction.json');
+  var luniiExport_optionAction = await fse.readJSON(__dirname + '/assets/luniiExport_optionAction.json');
 
-    await fse.emptyDir( __dirname + "/tmp");
-    const folder =  __dirname + "/tmp/atl-"+uid(16);
-    await fse.mkdirp(folder);
-    await fse.mkdirp(folder + '/assets');
-    const folderAssets = folder + '/assets/'
-    await fse.mkdirp(folder + '/assets_before');
-    const folderAssetsBefore = folder + '/assets_before/'
+  await fse.emptyDir( __dirname + "/tmp");
+  const folder =  __dirname + "/tmp/atl-"+uid(16);
+  await fse.mkdirp(folder);
+  await fse.mkdirp(folder + '/assets');
+  const folderAssets = folder + '/assets/'
+  await fse.mkdirp(folder + '/assets_before');
+  const folderAssetsBefore = folder + '/assets_before/'
 
-    podcast.title = title.replace(/[`~!@#$%^&*()_|+\-=?;:'",.<>\{\}\[\]\\\/]/gi, '');
-    podcast.description = 'no description';
-    podcast.audio = uid(16);
+  podcast.title = title.replace(/[`~!@#$%^&*()_|+\-=?;:'",.<>\{\}\[\]\\\/]/gi, '');
+  podcast.description = 'no description';
+  podcast.audio = uid(16);
+  //get title audio
+  var titleUrl = await googleTTS.getAudioUrl(podcast.title, { lang: 'fr' })
+  await wget(titleUrl, { output: folderAssetsBefore + podcast.audio + '.mp3' });
+  podcast.audio = podcast.audio + '.wav'
+  podcast.selectAudio = uid(16);
+  //get title audio
+  var titleSUrl = await googleTTS.getAudioUrl("Choisis ton histoire", { lang: 'fr' })
+  await wget(titleSUrl, { output: folderAssetsBefore + podcast.selectAudio + '.mp3' });
+  podcast.selectAudio = podcast.selectAudio + '.wav'
+
+  podcast.image = uid(16);
+  //get image
+  if(filesImage.length > 0) {
+    // allows for custom images for each story by using indexed jpg filenames
+    // just make sure to name files: 1.jpg, 2.jpg, 3.jpg, etc in the same folder as mp3 files
+    try {
+      for (const img of filesImage)
+        await fse.copy(img, folderAssetsBefore + '/'+ require('path').basename(img));
+    } catch (e) {}
+
+    await fse.copy(filesImage[0], folderAssetsBefore + '/'+ podcast.image + '.jpg');
+    await fse.copy(filesImage[0], folderAssetsBefore + '/thumbnail');
+  } else {
+    await fse.copy(__dirname + '/assets/thumbnail.png', folderAssetsBefore + '/'+ podcast.image + '.png');
+    await fse.copy(__dirname + '/assets/thumbnail.png', folderAssetsBefore + '/thumbnail');
+  }
+  
+  podcast.image = podcast.image + '.bmp'
+  podcast.uid = uuidv4();
+  podcast.menuUid = uuidv4();
+  podcast.groupId = uuidv4();
+  podcast.menuAction = uuidv4();
+  podcast.menuOption = uuidv4();
+
+  //on ajoute dans l'export
+  luniiExport.title = podcast.title + '_auto';
+  luniiExport.description = podcast.description
+  // on créé le stage menu
+  luniiExport_PackSelectionStage.uuid = podcast.uid;
+  luniiExport_PackSelectionStage.image = podcast.image;
+  luniiExport_PackSelectionStage.audio = podcast.audio;
+  luniiExport_PackSelectionStage.okTransition.actionNode = podcast.menuUid;
+  luniiExport.stageNodes.push(luniiExport_PackSelectionStage);
+  // on créé le 
+  luniiExport_questionStage.uuid = podcast.menuAction;
+  luniiExport_questionStage.groupId = podcast.groupId;
+  luniiExport_questionStage.audio = podcast.selectAudio;
+  luniiExport_questionStage.okTransition.actionNode = podcast.menuOption;
+  luniiExport.stageNodes.push(luniiExport_questionStage);
+  // on créé le questionActionStage 
+  luniiExport_questionAction.id = podcast.menuUid;
+  luniiExport_questionAction.groupId = podcast.groupId;
+  luniiExport_questionAction.options = [podcast.menuAction]
+  luniiExport.actionNodes.push(luniiExport_questionAction);
+  // on créé le optionStage
+  luniiExport_optionAction.id = podcast.menuOption;
+  luniiExport_optionAction.groupId = podcast.groupId;
+
+  bar1.increment();
+  var x = 1;
+  for (const item of files) {
+    var ext = path.extname(item)
+    var name = path.basename(item, ext);
+
+    story = Object.assign({}, {});
+    story.title = name.replace(/[`~!@#$%^&*()_|+\-=?;:'",.<>\{\}\[\]\\\/]/gi, '');
+    story.audio = uid(16);
     //get title audio
-    var titleUrl = await googleTTS.getAudioUrl(podcast.title, { lang: 'fr' })
-    await wget(titleUrl, { output: folderAssetsBefore + podcast.audio + '.mp3' });
-    podcast.audio = podcast.audio + '.wav'
-    podcast.selectAudio = uid(16);
-    //get title audio
-    var titleSUrl = await googleTTS.getAudioUrl("Choisis ton histoire", { lang: 'fr' })
-    await wget(titleSUrl, { output: folderAssetsBefore + podcast.selectAudio + '.mp3' });
-    podcast.selectAudio = podcast.selectAudio + '.wav'
-
-    podcast.image = uid(16);
+    var titleUrl = await googleTTS.getAudioUrl(story.title, { lang: 'fr' })
+    await wget(titleUrl, { output: folderAssetsBefore + story.audio + '.mp3' });
+    story.title = story.title.replace(/[`~!@#$%^&*()_|+\-=?;:'éèàêùûïîâ",.<>\{\}\[\]\\\/]/gi, '');
+    story.audio = story.audio + '.wav';
+    story.mp3 = uid(16);
     //get image
-    if(filesImage.length > 0) {
-      // allows for custom images for each story by using indexed jpg filenames
-      // just make sure to name files: 1.jpg, 2.jpg, 3.jpg, etc in the same folder as mp3 files
-      try {
-        for (const img of filesImage)
-          await fse.copy(img, folderAssetsBefore + '/'+ require('path').basename(img));
-      } catch (e) {}
+    await fse.copy(item, folderAssetsBefore + '/'+ story.mp3 + ext);
+    story.mp3 = story.mp3 + '.wav';
+    story.uid = uuidv4();
+    story.action = uuidv4();
+    story.storyAction = uuidv4();
 
-      await fse.copy(filesImage[0], folderAssetsBefore + '/'+ podcast.image + '.jpg');
-      await fse.copy(filesImage[0], folderAssetsBefore + '/thumbnail');
-    } else {
-      await fse.copy(__dirname + '/assets/thumbnail.png', folderAssetsBefore + '/'+ podcast.image + '.png');
-      await fse.copy(__dirname + '/assets/thumbnail.png', folderAssetsBefore + '/thumbnail');
-    }
-    
-    podcast.image = podcast.image + '.bmp'
-    podcast.uid = uuidv4();
-    podcast.menuUid = uuidv4();
-    podcast.groupId = uuidv4();
-    podcast.menuAction = uuidv4();
-    podcast.menuOption = uuidv4();
+    podcast.stories.push(story);
 
-    //on ajoute dans l'export
-    luniiExport.title = podcast.title + '_auto';
-    luniiExport.description = podcast.description
-    // on créé le stage menu
-    luniiExport_PackSelectionStage.uuid = podcast.uid;
-    luniiExport_PackSelectionStage.image = podcast.image;
-    luniiExport_PackSelectionStage.audio = podcast.audio;
-    luniiExport_PackSelectionStage.okTransition.actionNode = podcast.menuUid;
-    luniiExport.stageNodes.push(luniiExport_PackSelectionStage);
-    // on créé le 
-    luniiExport_questionStage.uuid = podcast.menuAction;
-    luniiExport_questionStage.groupId = podcast.groupId;
-    luniiExport_questionStage.audio = podcast.selectAudio;
-    luniiExport_questionStage.okTransition.actionNode = podcast.menuOption;
-    luniiExport.stageNodes.push(luniiExport_questionStage);
-    // on créé le questionActionStage 
-    luniiExport_questionAction.id = podcast.menuUid;
-    luniiExport_questionAction.groupId = podcast.groupId;
-    luniiExport_questionAction.options = [podcast.menuAction]
-    luniiExport.actionNodes.push(luniiExport_questionAction);
-    // on créé le optionStage
-    luniiExport_optionAction.id = podcast.menuOption;
-    luniiExport_optionAction.groupId = podcast.groupId;
+    // on créé la story
+    clone_luniiExport_Story = _.clone(luniiExport_Story);
+    clone_luniiExport_Story.uuid = story.uid;
+    clone_luniiExport_Story.name = story.title;
+    clone_luniiExport_Story.audio = story.mp3;
+    clone_luniiExport_Story.okTransition.actionNode = podcast.menuUid;
+    clone_luniiExport_Story.homeTransition.actionNode = podcast.menuUid;
+    clone_luniiExport_Story.groupId = story.uid;
+    luniiExport.stageNodes.push(JSON.parse(JSON.stringify(_.clone(clone_luniiExport_Story))))
 
+    // on créé l'action
+    clone_luniiExport_menuoptionStage = _.clone(luniiExport_menuoptionStage);
+    clone_luniiExport_menuoptionStage.uuid = story.action;
+    clone_luniiExport_menuoptionStage.groupId = podcast.groupId;
+    clone_luniiExport_menuoptionStage.name = story.title;
+    clone_luniiExport_menuoptionStage.image = x + '.bmp';
+    clone_luniiExport_menuoptionStage.audio = story.audio;
+    clone_luniiExport_menuoptionStage.okTransition.actionNode = _.clone(story.storyAction);
+    luniiExport.stageNodes.push(JSON.parse(JSON.stringify(_.clone(clone_luniiExport_menuoptionStage))));
+    luniiExport_optionAction.options.push(story.action);
+
+    // on créé la story Action
+    clone_luniiExport_StoryAction = _.clone(luniiExport_StoryAction);
+    clone_luniiExport_StoryAction.id = _.clone(_.clone(story.storyAction));
+    clone_luniiExport_StoryAction.groupId = story.uid;
+    clone_luniiExport_StoryAction.name = story.title + '.storyaction';
+    clone_luniiExport_StoryAction.options = [story.uid]
+    luniiExport.actionNodes.push(JSON.parse(JSON.stringify(_.clone(clone_luniiExport_StoryAction))));
+
+    delete story;
     bar1.increment();
-    var x = 1;
-    for (const item of files) {
-      var ext = path.extname(item)
-      var name = path.basename(item, ext);
+    x++;
+  }
 
-      story = Object.assign({}, {});
-      story.title = name.replace(/[`~!@#$%^&*()_|+\-=?;:'",.<>\{\}\[\]\\\/]/gi, '');
-      story.audio = uid(16);
-      //get title audio
-      var titleUrl = await googleTTS.getAudioUrl(story.title, { lang: 'fr' })
-      await wget(titleUrl, { output: folderAssetsBefore + story.audio + '.mp3' });
-      story.title = story.title.replace(/[`~!@#$%^&*()_|+\-=?;:'éèàêùûïîâ",.<>\{\}\[\]\\\/]/gi, '');
-      story.audio = story.audio + '.wav';
-      story.mp3 = uid(16);
-      //get image
-      await fse.copy(item, folderAssetsBefore + '/'+ story.mp3 + ext);
-      story.mp3 = story.mp3 + '.wav';
-      story.uid = uuidv4();
-      story.action = uuidv4();
-      story.storyAction = uuidv4();
+  luniiExport.actionNodes.push(luniiExport_optionAction);
 
-      podcast.stories.push(story);
+  var jsonContent = JSON.stringify(luniiExport);
 
-      // on créé la story
-      clone_luniiExport_Story = _.clone(luniiExport_Story);
-      clone_luniiExport_Story.uuid = story.uid;
-      clone_luniiExport_Story.name = story.title;
-      clone_luniiExport_Story.audio = story.mp3;
-      clone_luniiExport_Story.okTransition.actionNode = podcast.menuUid;
-      clone_luniiExport_Story.homeTransition.actionNode = podcast.menuUid;
-      clone_luniiExport_Story.groupId = story.uid;
-      luniiExport.stageNodes.push(JSON.parse(JSON.stringify(_.clone(clone_luniiExport_Story))))
+  // on traite les fichiers 
 
-      // on créé l'action
-      clone_luniiExport_menuoptionStage = _.clone(luniiExport_menuoptionStage);
-      clone_luniiExport_menuoptionStage.uuid = story.action;
-      clone_luniiExport_menuoptionStage.groupId = podcast.groupId;
-      clone_luniiExport_menuoptionStage.name = story.title;
-      clone_luniiExport_menuoptionStage.image = x + '.bmp';
-      clone_luniiExport_menuoptionStage.audio = story.audio;
-      clone_luniiExport_menuoptionStage.okTransition.actionNode = _.clone(story.storyAction);
-      luniiExport.stageNodes.push(JSON.parse(JSON.stringify(_.clone(clone_luniiExport_menuoptionStage))));
-      luniiExport_optionAction.options.push(story.action);
-
-      // on créé la story Action
-      clone_luniiExport_StoryAction = _.clone(luniiExport_StoryAction);
-      clone_luniiExport_StoryAction.id = _.clone(_.clone(story.storyAction));
-      clone_luniiExport_StoryAction.groupId = story.uid;
-      clone_luniiExport_StoryAction.name = story.title + '.storyaction';
-      clone_luniiExport_StoryAction.options = [story.uid]
-      luniiExport.actionNodes.push(JSON.parse(JSON.stringify(_.clone(clone_luniiExport_StoryAction))));
-
-      delete story;
-      bar1.increment();
-      x++;
-    }
-
-    luniiExport.actionNodes.push(luniiExport_optionAction);
-
-    var jsonContent = JSON.stringify(luniiExport);
-
-    // on traite les fichiers 
-
-    marketraitment(folderAssets, folderAssetsBefore, folder, podcast, jsonContent, luniiExport, limit, bar1 );
+  marketraitment(folderAssets, folderAssetsBefore, folder, podcast, jsonContent, luniiExport, limit, bar1 );
 }

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -227,9 +227,16 @@ exports.audio = async(pathFolder, title, lang) => {
   files = listFilesSync(pathFolder, 'mp3');
   filesImage = listFilesSync(pathFolder, 'jpg');
 
-  if(files.length == 0)
-    console.log("No MP3 files in directory");
-  else {
+  if (files.length == 0) {
+    files = listFilesSync(pathFolder, 'm4a');
+  }
+
+    if (files.length == 0) {
+      console.error("No mp3 OR m4a files in directory.");
+      process.exitCode = 1;
+      return;
+    }
+
     const bar1 = new cliProgress.SingleBar({}, cliProgress.Presets.shades_classic);
     var limit = files.length;
     bar1.start(parseInt(limit) + 8, 0);
@@ -316,7 +323,8 @@ exports.audio = async(pathFolder, title, lang) => {
     bar1.increment();
     var x = 1;
     for (const item of files) {
-      var name = path.basename(item, '.mp3');
+      var ext = path.extname(item)
+      var name = path.basename(item, ext);
 
       story = Object.assign({}, {});
       story.title = name.replace(/[`~!@#$%^&*()_|+\-=?;:'",.<>\{\}\[\]\\\/]/gi, '');
@@ -328,8 +336,7 @@ exports.audio = async(pathFolder, title, lang) => {
       story.audio = story.audio + '.wav';
       story.mp3 = uid(16);
       //get image
-      //await wget(item.enclosure.url, { output: folderAssetsBefore + story.mp3 + '.' + getExtension(item.enclosure.url) });
-      await fse.copy(item, folderAssetsBefore + '/'+ story.mp3 + '.mp3');
+      await fse.copy(item, folderAssetsBefore + '/'+ story.mp3 + ext);
       story.mp3 = story.mp3 + '.wav';
       story.uid = uuidv4();
       story.action = uuidv4();
@@ -378,6 +385,4 @@ exports.audio = async(pathFolder, title, lang) => {
     // on traite les fichiers 
 
     marketraitment(folderAssets, folderAssetsBefore, folder, podcast, jsonContent, luniiExport, limit, bar1 );
-
-  }
 }


### PR DESCRIPTION
Je suis en train d'enregistrer sur mon macbook et j'aimerais utiliser directement les fichiers `m4a`. Je vois qu'il y a une bonne partie du support à ces fichier déjà là, mais il manqueait juste une meilleure gestion de noms de fichiers lors de la fonction `audio`.

Le diff par défault sur le PR n'est pas super vu que mon changement vient reindenter en grand partie la fonction, mais si on ignore les espaces vides ça déviens beaucoup plus simple de valider les changements: https://github.com/laruche/audiotolunii/pull/4/files?diff=unified&w=1